### PR TITLE
Fix step indicator alignment

### DIFF
--- a/client/src/components/StepIndicator.jsx
+++ b/client/src/components/StepIndicator.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function StepIndicator({ steps, current }) {
   return (
-    <div className="flex items-center justify-between mb-4">
+    <div className="flex items-start justify-between mb-4">
       {steps.map((step, index) => (
         <div key={index} className="flex-1 text-center">
           <div


### PR DESCRIPTION
## Summary
- fix the vertical alignment of steps in StepIndicator

## Testing
- `npm --prefix client install`
- `npm --prefix client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840bab740b08329ac3f3c083d56d1df