### PR TITLE
Improve StepReview display

### DIFF
--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -1,16 +1,33 @@
 import React from 'react';
+import { FaRegFileAlt } from 'react-icons/fa';
 import PaycheckPreview from './PaycheckPreview';
 
 export default function StepReview({ form, onDownload }) {
+  const currencyFields = ['grossPay', 'extraWithholding', 'secondJobIncome', 'spouseIncome'];
+
+  const formatValue = (key, value) => {
+    if (currencyFields.includes(key)) {
+      const num = parseFloat(value);
+      if (isNaN(num)) return '$0';
+      return `$${num.toLocaleString()}`;
+    }
+    return String(value) || '—';
+  };
+
+  const entries = Object.entries(form).filter(([k]) => k !== 'step2b');
+
   return (
     <div className="space-y-6">
       <h2 className="text-lg font-semibold text-gray-800">Step 5: Review & Download</h2>
 
       <div className="bg-white rounded shadow-sm border border-gray-200 p-4 space-y-2">
-        {Object.entries(form).map(([key, value]) => (
-          <div key={key} className="flex justify-between text-sm text-gray-700">
-            <span className="capitalize">{key.replace(/([A-Z])/g, ' $1')}:</span>
-            <span className="text-right">{String(value) || '—'}</span>
+        {entries.map(([key, value]) => (
+          <div key={key} className="flex justify-between items-center text-sm text-gray-700">
+            <span className="capitalize flex items-center gap-1">
+              <FaRegFileAlt className="text-gray-500" />
+              {key.replace(/([A-Z])/g, ' $1')}
+            </span>
+            <span className="text-right">{formatValue(key, value)}</span>
           </div>
         ))}
       </div>

--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -10,3 +10,26 @@ test('calls onDownload when button clicked', async () => {
   await userEvent.click(screen.getByRole('button', { name: /download/i }));
   expect(onDownload).toHaveBeenCalled();
 });
+
+test('does not display step2b data', () => {
+  render(
+    <StepReview
+      form={{ grossPay: 1000, step2b: { line1: 1 } }}
+      onDownload={() => {}}
+    />,
+  );
+  expect(screen.queryByText(/step2b/i)).not.toBeInTheDocument();
+});
+
+test('formats currency fields with dollar sign', () => {
+  render(
+    <StepReview
+      form={{ grossPay: 1000, extraWithholding: 50, secondJobIncome: 20, spouseIncome: 30 }}
+      onDownload={() => {}}
+    />,
+  );
+  expect(screen.getByText('$1,000')).toBeInTheDocument();
+  expect(screen.getByText('$50')).toBeInTheDocument();
+  expect(screen.getByText('$20')).toBeInTheDocument();
+  expect(screen.getByText('$30')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- remove `step2b` from review display
- show icons for each review field
- format selected values with dollar signs
- add tests for StepReview formatting

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840bc810a308329967e72c6c738ad7a