### PR TITLE
Fix dropdown chevron spacing

### DIFF
--- a/client/src/components/StepFilingStatus.jsx
+++ b/client/src/components/StepFilingStatus.jsx
@@ -13,7 +13,7 @@ export default function StepFilingStatus({ form, setForm }) {
           id="filingStatus"
           value={form.filingStatus || 'single'}
           onChange={(e) => setForm({ ...form, filingStatus: e.target.value })}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 pr-8"
         >
           <option value="single">Single</option>
           <option value="married">Married Filing Jointly</option>
@@ -29,7 +29,7 @@ export default function StepFilingStatus({ form, setForm }) {
           id="payFrequency"
           value={form.payFrequency || 'biweekly'}
           onChange={(e) => setForm({ ...form, payFrequency: e.target.value })}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
+          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2 pr-8"
         >
           <option value="weekly">Weekly</option>
           <option value="biweekly">Biweekly</option>


### PR DESCRIPTION
## Summary
- widen padding on dropdowns so the chevron isn't flush against the edge

## Testing
- `npm test -- --runInBand --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840c3b4a6688329b871e6550522b6d4