### PR TITLE
Fix review defaults

### DIFF
--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -3,7 +3,36 @@ import { FaRegFileAlt } from 'react-icons/fa';
 import PaycheckPreview from './PaycheckPreview';
 
 export default function StepReview({ form, onDownload }) {
-  const currencyFields = ['grossPay', 'extraWithholding', 'secondJobIncome', 'spouseIncome'];
+  const defaults = {
+    filingStatus: 'single',
+    payFrequency: 'biweekly',
+    grossPay: '',
+    multipleJobs: false,
+    exempt: false,
+    secondJobIncome: '',
+    spouseIncome: '',
+    jobCount: 0,
+    itemizedDeductions: 0,
+    adjustmentDeductions: 0,
+    deductions: 0,
+    under17: 0,
+    otherDependents: 0,
+    otherIncome: 0,
+    pretaxDeductions: 0,
+    extraWithholding: 0,
+  };
+
+  const currencyFields = [
+    'grossPay',
+    'extraWithholding',
+    'secondJobIncome',
+    'spouseIncome',
+    'otherIncome',
+    'pretaxDeductions',
+    'itemizedDeductions',
+    'adjustmentDeductions',
+    'deductions',
+  ];
 
   const formatValue = (key, value) => {
     if (currencyFields.includes(key)) {
@@ -14,7 +43,9 @@ export default function StepReview({ form, onDownload }) {
     return String(value) || '—';
   };
 
-  const entries = Object.entries(form).filter(([k]) => k !== 'step2b');
+  const entries = Object.entries({ ...defaults, ...form }).filter(
+    ([k]) => k !== 'step2b',
+  );
 
   return (
     <div className="space-y-6">

--- a/client/src/components/StepperForm.jsx
+++ b/client/src/components/StepperForm.jsx
@@ -16,7 +16,26 @@ import jsPDF from 'jspdf';
 
 export default function StepperForm() {
   const [currentStep, setCurrentStep] = useState(0);
-  const [form, setForm] = useState({});
+  const defaultForm = {
+    filingStatus: 'single',
+    payFrequency: 'biweekly',
+    grossPay: '',
+    multipleJobs: false,
+    exempt: false,
+    secondJobIncome: '',
+    spouseIncome: '',
+    jobCount: 0,
+    itemizedDeductions: 0,
+    adjustmentDeductions: 0,
+    deductions: 0,
+    under17: 0,
+    otherDependents: 0,
+    otherIncome: 0,
+    pretaxDeductions: 0,
+    extraWithholding: 0,
+  };
+
+  const [form, setForm] = useState(defaultForm);
 
   const goNext = () => setCurrentStep((s) => Math.min(s + 1, steps.length - 1));
   const goBack = () => setCurrentStep((s) => Math.max(s - 1, 0));

--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -33,3 +33,12 @@ test('formats currency fields with dollar sign', () => {
   expect(screen.getByText('$20')).toBeInTheDocument();
   expect(screen.getByText('$30')).toBeInTheDocument();
 });
+
+test('shows default values when form is empty', () => {
+  render(<StepReview form={{}} onDownload={() => {}} />);
+  expect(screen.getByText('filing Status')).toBeInTheDocument();
+  expect(screen.getByText('single')).toBeInTheDocument();
+  expect(screen.getByText('pay Frequency')).toBeInTheDocument();
+  expect(screen.getByText('biweekly')).toBeInTheDocument();
+  expect(screen.getAllByText('$0').length).toBeGreaterThan(0);
+});

--- a/client/src/components/__tests__/StepperForm.test.jsx
+++ b/client/src/components/__tests__/StepperForm.test.jsx
@@ -11,5 +11,7 @@ test('navigates between steps', async () => {
   expect(screen.getByText(/welcome to the w-4 calculator/i)).toBeInTheDocument();
   await userEvent.click(screen.getByText(/next/i));
   // Next step should show filing status heading
-  expect(screen.getByText(/step 2/i)).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { name: /filing status/i })
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- initialize form state with default values
- show default values in the Review step
- adjust StepperForm tests for heading
- add a test verifying defaults display in Review step

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840c504a7588329911ec240735e0115