### PR TITLE
Update 2025 standard deduction values

### DIFF
--- a/client/src/components/utils/calculateStep4b.js
+++ b/client/src/components/utils/calculateStep4b.js
@@ -3,7 +3,9 @@ export function calculateStep4b({
   itemizedDeductions = 0,
   adjustmentDeductions = 0,
 }) {
-  const stdMap = { single: 14600, married: 29200, head: 21900 };
+  // Standard deduction amounts for the 2025 tax year
+  // Source: Form W-4 (2025) deductions worksheet
+  const stdMap = { single: 15000, married: 30000, head: 22500 };
   const line1 = parseFloat(itemizedDeductions) || 0;
   const line2 = stdMap[filingStatus] || stdMap.single;
   const line3 = Math.max(0, line1 - line2);

--- a/client/src/components/utils/calculateTax.js
+++ b/client/src/components/utils/calculateTax.js
@@ -1,11 +1,13 @@
 
 export function calculateTax(filingStatus, annualIncome, deductions) {
+    // Standard deduction amounts for the 2025 tax year
+    // Source: Form W-4 (2025)
     const stdDeductionMap = {
-        single: 14600,
-        married: 29200,
-        head: 21900,
+        single: 15000,
+        married: 30000,
+        head: 22500,
     };
-    const stdDeduction = stdDeductionMap[filingStatus] || 14600;    
+    const stdDeduction = stdDeductionMap[filingStatus] || stdDeductionMap.single;
     const taxBrackets = {
         single: [
             [0, 0.10],


### PR DESCRIPTION
## Summary
- update deduction constants in `calculateStep4b` and `calculateTax`
- default to 2025 single deduction amount

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840c960362c8329ab3a195966589e39