### PR TITLE
Clarify deduction label

### DIFF
--- a/client/src/components/StepDeductionsWorksheet.jsx
+++ b/client/src/components/StepDeductionsWorksheet.jsx
@@ -42,9 +42,9 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
         max={1000000}
       />
 
-      <div className="p-3 bg-blue-50 border border-blue-200 rounded">
-        <p className="text-sm text-blue-800">Total deductions: ${line5.toLocaleString()}</p>
-      </div>
+        <div className="p-3 bg-blue-50 border border-blue-200 rounded">
+          <p className="text-sm text-blue-800">Total deductions (beyond standard deduction): ${line5.toLocaleString()}</p>
+        </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- clarify that total deductions shown in the deductions worksheet are beyond the standard deduction

## Testing
- `npm install --silent`
- `CI=true npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6840e208bff48329a815d848bafe7d4e