### PR TITLE
Add test for pretax formatting

### DIFF
--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -34,6 +34,13 @@ test('formats currency fields with dollar sign', () => {
   expect(screen.getByText('$30')).toBeInTheDocument();
 });
 
+test('formats pretax deductions with dollar sign and commas', () => {
+  render(
+    <StepReview form={{ pretaxDeductions: 12345 }} onDownload={() => {}} />,
+  );
+  expect(screen.getByText('$12,345')).toBeInTheDocument();
+});
+
 test('shows default values when form is empty', () => {
   render(<StepReview form={{}} onDownload={() => {}} />);
   expect(screen.getByText('filing Status')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add test to ensure pretax deductions display uses `$` and commas in Review & Download

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840e43f705c8329a6be527a9e54da69