### PR TITLE
Fix step4b showing in review

### DIFF
--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -43,9 +43,8 @@ export default function StepReview({ form, onDownload }) {
     return String(value) || '—';
   };
 
-  const entries = Object.entries({ ...defaults, ...form }).filter(
-    ([k]) => !['step2b', 'step4b'].includes(k),
-  );
+  const { step2b, step4b, ...filteredForm } = { ...defaults, ...form };
+  const entries = Object.entries(filteredForm);
 
   const labelMap = {
     under17: 'Number of Dependents under 17',


### PR DESCRIPTION
## Summary
- ensure `step4b` details are filtered out in the Review & Download list

## Testing
- `npm install --silent`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840e3dc94d4832997a6622a29afc8c3