### PR TITLE
Add tooltips to all form fields

### DIFF
--- a/client/src/components/CurrencyInput.jsx
+++ b/client/src/components/CurrencyInput.jsx
@@ -69,6 +69,7 @@ export default function CurrencyInput({
         onChange={handleChange}
         onBlur={handleBlur}
         placeholder="$0"
+        title={helperText}
         className={`w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 ${
           error
             ? 'border-red-500 focus:ring-red-500'

--- a/client/src/components/StepAdjustments.jsx
+++ b/client/src/components/StepAdjustments.jsx
@@ -12,7 +12,11 @@ export default function StepAdjustments({ form, setForm }) {
     <div className="space-y-4">
       <h2 className="text-lg font-semibold text-gray-800">Adjustments</h2>
       <div>
-        <label htmlFor="under17" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="under17"
+          className="block text-sm font-medium text-gray-700"
+          title="Number of dependents under age 17"
+        >
           Dependents Under 17
         </label>
         <input
@@ -26,7 +30,11 @@ export default function StepAdjustments({ form, setForm }) {
         />
       </div>
       <div>
-        <label htmlFor="otherDependents" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="otherDependents"
+          className="block text-sm font-medium text-gray-700"
+          title="Dependents age 17 or older"
+        >
           Other Dependents
         </label>
         <input
@@ -44,7 +52,11 @@ export default function StepAdjustments({ form, setForm }) {
       <div>
         <CurrencyInput
           label={
-            <label htmlFor="otherIncome" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="otherIncome"
+              className="block text-sm font-medium text-gray-700"
+              title="Other income you expect to receive this year"
+            >
               Other Income (Annual)
             </label>
           }
@@ -62,7 +74,11 @@ export default function StepAdjustments({ form, setForm }) {
 
         <CurrencyInput
           label={
-            <label htmlFor="pretaxDeductions" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="pretaxDeductions"
+              className="block text-sm font-medium text-gray-700"
+              title="Annual 401(k), HSA, or other pre-tax amounts"
+            >
               Pre-tax Contributions (Annual, e.g. 401(k), HSA)
             </label>
           }
@@ -79,7 +95,11 @@ export default function StepAdjustments({ form, setForm }) {
       <div>
         <CurrencyInput
           label={
-            <label htmlFor="extraWithholding" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="extraWithholding"
+              className="block text-sm font-medium text-gray-700"
+              title="Any additional amount to withhold each paycheck"
+            >
               Extra Withholding per Paycheck
             </label>
           }

--- a/client/src/components/StepDeductionsWorksheet.jsx
+++ b/client/src/components/StepDeductionsWorksheet.jsx
@@ -26,20 +26,30 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
       <h2 className="text-lg font-semibold text-gray-800">Deductions</h2>
 
       <CurrencyInput
-        label={<label htmlFor="itemizedDeductions" className="block text-sm font-medium text-gray-700">Estimated itemized deductions</label>}
+        label={
+          <span title="Estimated total of your itemized deductions">
+            Estimated itemized deductions
+          </span>
+        }
         name="itemizedDeductions"
         value={form.itemizedDeductions}
         onChange={(field, val) => setForm({ ...form, [field]: val })}
         min={0}
         max={1000000}
+        helperText="Amount of itemized deductions beyond the standard deduction"
       />
       <CurrencyInput
-        label={<label htmlFor="adjustmentDeductions" className="block text-sm font-medium text-gray-700">Other adjustments to income</label>}
+        label={
+          <span title="Adjustments that reduce your taxable income">
+            Other adjustments to income
+          </span>
+        }
         name="adjustmentDeductions"
         value={form.adjustmentDeductions}
         onChange={(field, val) => setForm({ ...form, [field]: val })}
         min={0}
         max={1000000}
+        helperText="Other adjustments that reduce income"
       />
 
         <div className="p-3 bg-blue-50 border border-blue-200 rounded">

--- a/client/src/components/StepFilingStatus.jsx
+++ b/client/src/components/StepFilingStatus.jsx
@@ -6,7 +6,11 @@ export default function StepFilingStatus({ form, setForm }) {
       <h2 className="text-lg font-semibold text-gray-800">Filing Status & Pay Frequency</h2>
 
       <div>
-        <label htmlFor="filingStatus" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="filingStatus"
+          className="block text-sm font-medium text-gray-700"
+          title="Select your tax filing status"
+        >
           Filing Status
         </label>
         <select
@@ -22,7 +26,11 @@ export default function StepFilingStatus({ form, setForm }) {
       </div>
 
       <div>
-        <label htmlFor="payFrequency" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="payFrequency"
+          className="block text-sm font-medium text-gray-700"
+          title="How often you receive a paycheck"
+        >
           Pay Frequency
         </label>
         <select

--- a/client/src/components/StepIncomeDetails.jsx
+++ b/client/src/components/StepIncomeDetails.jsx
@@ -17,7 +17,11 @@ export default function StepIncomeDetails({ form, setForm }) {
       <div>
         <CurrencyInput
           label={
-            <label htmlFor="grossPay" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="grossPay"
+              className="block text-sm font-medium text-gray-700"
+              title="Your yearly income before taxes"
+            >
               Annual Gross Pay
             </label>
           }
@@ -36,7 +40,11 @@ export default function StepIncomeDetails({ form, setForm }) {
           checked={form.multipleJobs || false}
           onChange={(e) => setForm({ ...form, multipleJobs: e.target.checked })}
         />
-        <label htmlFor="multipleJobs" className="text-sm text-gray-700">
+        <label
+          htmlFor="multipleJobs"
+          className="text-sm text-gray-700"
+          title="Check if you have more than one job or your spouse works"
+        >
           Multiple jobs or spouse works?
         </label>
       </div>
@@ -48,7 +56,11 @@ export default function StepIncomeDetails({ form, setForm }) {
           checked={form.exempt || false}
           onChange={(e) => setForm({ ...form, exempt: e.target.checked })}
         />
-        <label htmlFor="exempt" className="text-sm text-gray-700">
+        <label
+          htmlFor="exempt"
+          className="text-sm text-gray-700"
+          title="Check if you are exempt from federal withholding"
+        >
           Exempt from withholding?
         </label>
       </div>

--- a/client/src/components/StepMultipleJobs.jsx
+++ b/client/src/components/StepMultipleJobs.jsx
@@ -36,7 +36,11 @@ export default function StepMultipleJobs({ form, setForm }) {
       <div>
         <CurrencyInput
           label={
-            <label htmlFor="grossPay" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="grossPay"
+              className="block text-sm font-medium text-gray-700"
+              title="Income you earn from a second job"
+            >
               Income from second job
             </label>
           }
@@ -51,7 +55,11 @@ export default function StepMultipleJobs({ form, setForm }) {
       <div>
         <CurrencyInput
           label={
-            <label htmlFor="spouseIncome" className="block text-sm font-medium text-gray-700">
+            <label
+              htmlFor="spouseIncome"
+              className="block text-sm font-medium text-gray-700"
+              title="Your spouse's annual income"
+            >
               Spouse's income
             </label>
           }
@@ -64,7 +72,10 @@ export default function StepMultipleJobs({ form, setForm }) {
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700">
+        <label
+          className="block text-sm font-medium text-gray-700"
+          title="Total number of jobs in your household"
+        >
           Total household job count
         </label>
         <input

--- a/client/src/components/StepPersonalInfo.jsx
+++ b/client/src/components/StepPersonalInfo.jsx
@@ -6,7 +6,11 @@ export default function StepPersonalInfo({ form, setForm }) {
       <h2 className="text-lg font-semibold text-gray-800">Personal Information</h2>
 
       <div>
-        <label htmlFor="firstName" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="firstName"
+          className="block text-sm font-medium text-gray-700"
+          title="Enter your first name"
+        >
           First Name
         </label>
         <input
@@ -20,7 +24,11 @@ export default function StepPersonalInfo({ form, setForm }) {
       </div>
 
       <div>
-        <label htmlFor="lastName" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="lastName"
+          className="block text-sm font-medium text-gray-700"
+          title="Enter your last name"
+        >
           Last Name
         </label>
         <input
@@ -34,7 +42,11 @@ export default function StepPersonalInfo({ form, setForm }) {
       </div>
 
       <div>
-        <label htmlFor="ssn" className="block text-sm font-medium text-gray-700">
+        <label
+          htmlFor="ssn"
+          className="block text-sm font-medium text-gray-700"
+          title="Enter the last four digits of your SSN"
+        >
           SSN (Last 4 digits)
         </label>
         <input

--- a/client/src/components/__tests__/StepDeductionsWorksheet.test.jsx
+++ b/client/src/components/__tests__/StepDeductionsWorksheet.test.jsx
@@ -3,5 +3,7 @@ import StepDeductionsWorksheet from '../StepDeductionsWorksheet';
 
 test('shows itemized deductions input', () => {
   render(<StepDeductionsWorksheet form={{}} setForm={() => {}} />);
-  expect(screen.getByText(/itemized deductions/i)).toBeInTheDocument();
+  expect(
+    screen.getByTitle(/itemized deductions beyond the standard/i)
+  ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- enhance CurrencyInput so helper text appears as a tooltip
- add `title` attributes to form field labels for tooltips
- update StepDeductionsWorksheet helper text and labels
- adjust related test to locate the field via tooltip

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840f1384d388329a3fca289c8ab032c