### PR TITLE
Normalize field labels to title case

### DIFF
--- a/client/src/components/StepDeductionsWorksheet.jsx
+++ b/client/src/components/StepDeductionsWorksheet.jsx
@@ -26,7 +26,7 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
       <h2 className="text-lg font-semibold text-gray-800">Deductions</h2>
 
       <CurrencyInput
-        label={<label htmlFor="itemizedDeductions" className="block text-sm font-medium text-gray-700">Estimated itemized deductions</label>}
+        label={<label htmlFor="itemizedDeductions" className="block text-sm font-medium text-gray-700">Estimated Itemized Deductions</label>}
         name="itemizedDeductions"
         value={form.itemizedDeductions}
         onChange={(field, val) => setForm({ ...form, [field]: val })}
@@ -34,7 +34,7 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
         max={1000000}
       />
       <CurrencyInput
-        label={<label htmlFor="adjustmentDeductions" className="block text-sm font-medium text-gray-700">Other adjustments to income</label>}
+        label={<label htmlFor="adjustmentDeductions" className="block text-sm font-medium text-gray-700">Other Adjustments to Income</label>}
         name="adjustmentDeductions"
         value={form.adjustmentDeductions}
         onChange={(field, val) => setForm({ ...form, [field]: val })}
@@ -43,7 +43,7 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
       />
 
         <div className="p-3 bg-blue-50 border border-blue-200 rounded">
-          <p className="text-sm text-blue-800">Total deductions (beyond standard deduction): ${line5.toLocaleString()}</p>
+          <p className="text-sm text-blue-800">Total Deductions (Beyond Standard Deduction): ${line5.toLocaleString()}</p>
         </div>
     </div>
   );

--- a/client/src/components/StepIncomeDetails.jsx
+++ b/client/src/components/StepIncomeDetails.jsx
@@ -37,7 +37,7 @@ export default function StepIncomeDetails({ form, setForm }) {
           onChange={(e) => setForm({ ...form, multipleJobs: e.target.checked })}
         />
         <label htmlFor="multipleJobs" className="text-sm text-gray-700">
-          Multiple jobs or spouse works?
+          Multiple Jobs or Spouse Works?
         </label>
       </div>
 
@@ -49,7 +49,7 @@ export default function StepIncomeDetails({ form, setForm }) {
           onChange={(e) => setForm({ ...form, exempt: e.target.checked })}
         />
         <label htmlFor="exempt" className="text-sm text-gray-700">
-          Exempt from withholding?
+          Exempt from Withholding?
         </label>
       </div>
     </div>

--- a/client/src/components/StepMultipleJobs.jsx
+++ b/client/src/components/StepMultipleJobs.jsx
@@ -37,7 +37,7 @@ export default function StepMultipleJobs({ form, setForm }) {
         <CurrencyInput
           label={
             <label htmlFor="grossPay" className="block text-sm font-medium text-gray-700">
-              Income from second job
+              Income from Second Job
             </label>
           }
           name="secondJobIncome"
@@ -52,7 +52,7 @@ export default function StepMultipleJobs({ form, setForm }) {
         <CurrencyInput
           label={
             <label htmlFor="spouseIncome" className="block text-sm font-medium text-gray-700">
-              Spouse's income
+              Spouse's Income
             </label>
           }
           name="spouseIncome"
@@ -65,7 +65,7 @@ export default function StepMultipleJobs({ form, setForm }) {
 
       <div>
         <label className="block text-sm font-medium text-gray-700">
-          Total household job count
+          Total Household Job Count
         </label>
         <input
           type="number"
@@ -80,7 +80,7 @@ export default function StepMultipleJobs({ form, setForm }) {
       {form.step2b && (
         <div className="p-3 bg-blue-50 border border-blue-200 rounded">
           <p className="text-sm text-blue-800">
-            Estimated extra withholding per paycheck:{' '}
+            Estimated Extra Withholding per Paycheck:{' '}
             <strong>${form.step2b.line4}</strong>
           </p>
         </div>

--- a/client/src/components/StepPersonalInfo.jsx
+++ b/client/src/components/StepPersonalInfo.jsx
@@ -35,7 +35,7 @@ export default function StepPersonalInfo({ form, setForm }) {
 
       <div>
         <label htmlFor="ssn" className="block text-sm font-medium text-gray-700">
-          SSN (Last 4 digits)
+          SSN (Last 4 Digits)
         </label>
         <input
           id="ssn"

--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -47,8 +47,33 @@ export default function StepReview({ form, onDownload }) {
   const entries = Object.entries(filteredForm);
 
   const labelMap = {
-    under17: 'Number of Dependents under 17',
+    under17: 'Number of Dependents Under 17',
   };
+
+  const smallWords = [
+    'and',
+    'or',
+    'the',
+    'a',
+    'an',
+    'in',
+    'on',
+    'with',
+    'from',
+    'to',
+    'per',
+    'of',
+  ];
+
+  const toTitleCase = (text) =>
+    text
+      .split(' ')
+      .map((word) =>
+        smallWords.includes(word.toLowerCase())
+          ? word.toLowerCase()
+          : word.charAt(0).toUpperCase() + word.slice(1)
+      )
+      .join(' ');
 
   return (
     <div className="space-y-6">
@@ -56,11 +81,11 @@ export default function StepReview({ form, onDownload }) {
 
       <div className="bg-white rounded shadow-sm border border-gray-200 p-6 space-y-2">
         {entries.map(([key, value]) => {
-          const label = labelMap[key] || key.replace(/([A-Z])/g, ' $1');
-          const labelClass = labelMap[key] ? '' : 'capitalize';
+          const rawLabel = labelMap[key] || key.replace(/([A-Z])/g, ' $1');
+          const label = toTitleCase(rawLabel);
           return (
             <div key={key} className="flex justify-between items-center text-sm text-gray-700">
-              <span className={`${labelClass} flex items-center gap-1`}>
+              <span className="flex items-center gap-1">
                 <FaRegFileAlt className="text-gray-500" />
                 {label}
               </span>

--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -43,9 +43,9 @@ test('formats pretax deductions with dollar sign and commas', () => {
 
 test('shows default values when form is empty', () => {
   render(<StepReview form={{}} onDownload={() => {}} />);
-  expect(screen.getByText('filing Status')).toBeInTheDocument();
+  expect(screen.getByText('Filing Status')).toBeInTheDocument();
   expect(screen.getByText('single')).toBeInTheDocument();
-  expect(screen.getByText('pay Frequency')).toBeInTheDocument();
+  expect(screen.getByText('Pay Frequency')).toBeInTheDocument();
   expect(screen.getByText('biweekly')).toBeInTheDocument();
   expect(screen.getAllByText('$0').length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- ensure title case for field labels in the step components
- update StepReview to compute labels in title case
- adjust StepReview tests accordingly

## Testing
- `npm test --silent --maxWorkers=50`

------
https://chatgpt.com/codex/tasks/task_e_6840f1b93d308329b449a4144dfb21c8