### PR TITLE
Add vertical step layout and PDF preview

### DIFF
--- a/client/src/components/PdfPreview.jsx
+++ b/client/src/components/PdfPreview.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { fillW4Template } from './utils/fillW4Template';
+
+export default function PdfPreview({ form }) {
+  const [url, setUrl] = useState(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const generate = async () => {
+      try {
+        const pdfBytes = await fillW4Template(form);
+        const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+        const newUrl = URL.createObjectURL(blob);
+        if (isMounted) {
+          setUrl((prev) => {
+            if (prev) URL.revokeObjectURL(prev);
+            return newUrl;
+          });
+        }
+      } catch (err) {
+        console.error('Failed to generate preview', err);
+      }
+    };
+    generate();
+    return () => {
+      isMounted = false;
+      setUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return null;
+      });
+    };
+  }, [form]);
+
+  if (!url) return <div className="text-gray-500">Generating preview...</div>;
+
+  return (
+    <iframe
+      title="W-4 Preview"
+      src={url}
+      className="w-full h-full min-h-[70vh] border rounded"
+    />
+  );
+}

--- a/client/src/components/StepIndicator.jsx
+++ b/client/src/components/StepIndicator.jsx
@@ -2,18 +2,16 @@ import React from 'react';
 
 export default function StepIndicator({ steps, current }) {
   return (
-    <div className="flex items-start justify-between mb-4 overflow-x-auto">
+    <div className="flex flex-col items-start space-y-3 mb-4">
       {steps.map((step, index) => (
-        <div key={index} className="flex-1 text-center">
+        <div key={index} className="flex items-center space-x-2">
           <div
-            className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center text-sm font-bold
+            className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold
               ${index === current ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-600'}`}
           >
             {index + 1}
           </div>
-          <p className={`mt-1 text-xs ${index === current ? 'text-blue-600 font-medium' : 'text-gray-500'}`}>
-            {step.title}
-          </p>
+          <p className={`text-sm ${index === current ? 'text-blue-600 font-medium' : 'text-gray-500'}`}>{step.title}</p>
         </div>
       ))}
     </div>

--- a/client/src/components/StepperForm.jsx
+++ b/client/src/components/StepperForm.jsx
@@ -7,6 +7,7 @@ import StepAdjustments from './StepAdjustments';
 import StepDeductionsWorksheet from './StepDeductionsWorksheet';
 import StepReview from './StepReview';
 import StepIntro from './StepIntro';
+import PdfPreview from './PdfPreview';
 import { fillW4Template } from './utils/fillW4Template';
 
 
@@ -74,28 +75,36 @@ const steps = [
 
   const StepComponent = steps[currentStep].Component;
   return (
-    <div className="max-w-6xl w-full mx-auto bg-white shadow-xl rounded-xl px-8 sm:px-12 py-12 space-y-6">
-      <StepIndicator steps={steps} current={currentStep} />
-      <StepComponent form={form} setForm={setForm} onDownload={handleDownload} />
+    <div className="max-w-6xl w-full mx-auto bg-white shadow-xl rounded-xl px-4 sm:px-8 py-8">
+      <div className="flex flex-col md:flex-row gap-6">
+        <div className="md:w-1/2 space-y-6">
+          <StepIndicator steps={steps} current={currentStep} />
+          <StepComponent form={form} setForm={setForm} onDownload={handleDownload} />
 
-      <div className="flex justify-between items-center mt-6 px-4">
-        <button
-          type="button"
-          onClick={goBack}
-          disabled={currentStep === 0}
-          className="px-4 py-2 rounded border border-gray-400 text-gray-700 disabled:opacity-30"
-        >
-          Back
-        </button>
-        {currentStep < steps.length - 1 ? (
-          <button
-            type="button"
-            onClick={goNext}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
-          >
-            Next
-          </button>
-        ) : null}
+          <div className="flex justify-between items-center mt-6">
+            <button
+              type="button"
+              onClick={goBack}
+              disabled={currentStep === 0}
+              className="px-4 py-2 rounded border border-gray-400 text-gray-700 disabled:opacity-30"
+            >
+              Back
+            </button>
+            {currentStep < steps.length - 1 ? (
+              <button
+                type="button"
+                onClick={goNext}
+                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+              >
+                Next
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="md:w-1/2">
+          <PdfPreview form={form} />
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/__tests__/StepperForm.test.jsx
+++ b/client/src/components/__tests__/StepperForm.test.jsx
@@ -4,6 +4,7 @@ import StepperForm from '../StepperForm';
 
 jest.mock('jspdf', () => jest.fn());
 jest.mock('../utils/fillW4Template', () => ({ fillW4Template: jest.fn() }));
+jest.mock('../PdfPreview', () => () => <div>PDF Preview</div>);
 
 test('navigates between steps', async () => {
   render(<StepperForm />);


### PR DESCRIPTION
## Summary
- make `StepIndicator` vertical
- add new `PdfPreview` component to render filled PDF
- update `StepperForm` to use two-pane layout with preview
- adjust tests for `StepperForm`

## Testing
- `npm test -- -u --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840fe2ab76083299ee04c7238d90c72