### PR TITLE
Simplify personal info step

### DIFF
--- a/client/src/components/StepPersonalInfo.jsx
+++ b/client/src/components/StepPersonalInfo.jsx
@@ -1,81 +1,9 @@
 import React from 'react';
 
 export default function StepPersonalInfo({ form, setForm }) {
-  const handleChange = (field) => (e) => {
-    setForm({ ...form, [field]: e.target.value });
-  };
-
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-semibold text-gray-800">Personal Information</h2>
-      <p className="text-sm text-gray-600">
-        This information is not stored anywhere and will solely be used to populate the W-4 form.
-      </p>
-
-      <div>
-        <label htmlFor="firstName" className="block text-sm font-medium text-gray-700">
-          First name and initial
-        </label>
-        <input
-          id="firstName"
-          type="text"
-          value={form.firstName || ''}
-          onChange={handleChange('firstName')}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="lastName" className="block text-sm font-medium text-gray-700">
-          Last Name
-        </label>
-        <input
-          id="lastName"
-          type="text"
-          value={form.lastName || ''}
-          onChange={handleChange('lastName')}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="address" className="block text-sm font-medium text-gray-700">
-          Address
-        </label>
-        <input
-          id="address"
-          type="text"
-          value={form.address || ''}
-          onChange={handleChange('address')}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="cityStateZip" className="block text-sm font-medium text-gray-700">
-          City, State, Zipcode
-        </label>
-        <input
-          id="cityStateZip"
-          type="text"
-          value={form.cityStateZip || ''}
-          onChange={handleChange('cityStateZip')}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="ssn" className="block text-sm font-medium text-gray-700">
-          Social Security Number
-        </label>
-        <input
-          id="ssn"
-          type="text"
-          value={form.ssn || ''}
-          onChange={handleChange('ssn')}
-          className="mt-1 block w-full rounded border border-gray-300 px-3 py-2"
-        />
-      </div>
+      <h2 className="text-lg font-semibold text-gray-800">Filing Status</h2>
 
       <div>
         <label

--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -4,11 +4,6 @@ import PaycheckPreview from './PaycheckPreview';
 
 export default function StepReview({ form, onDownload }) {
   const defaults = {
-    firstName: '',
-    lastName: '',
-    address: '',
-    cityStateZip: '',
-    ssn: '',
     filingStatus: 'single',
     payFrequency: 'biweekly',
     grossPay: '',

--- a/client/src/components/StepperForm.jsx
+++ b/client/src/components/StepperForm.jsx
@@ -16,11 +16,6 @@ import jsPDF from 'jspdf';
 export default function StepperForm() {
   const [currentStep, setCurrentStep] = useState(0);
   const defaultForm = {
-    firstName: '',
-    lastName: '',
-    address: '',
-    cityStateZip: '',
-    ssn: '',
     filingStatus: 'single',
     payFrequency: 'biweekly',
     grossPay: '',
@@ -62,7 +57,7 @@ export default function StepperForm() {
 
 const steps = [
   { title: 'Welcome', Component: StepIntro },
-  { title: 'Personal Info', Component: StepPersonalInfo },
+  { title: 'Filing Status', Component: StepPersonalInfo },
   { title: 'Pay & Withholding', Component: StepIncomeDetails },
   ...(form.multipleJobs
     ? [{ title: 'Multiple Jobs Worksheet', Component: StepMultipleJobs }]

--- a/client/src/components/__tests__/StepPersonalInfo.test.jsx
+++ b/client/src/components/__tests__/StepPersonalInfo.test.jsx
@@ -2,9 +2,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import StepPersonalInfo from '../StepPersonalInfo';
 
-test('updates personal info fields', async () => {
+test('updates filing status', async () => {
   const setForm = jest.fn();
   render(<StepPersonalInfo form={{}} setForm={setForm} />);
-  await userEvent.type(screen.getByLabelText(/first name/i), 'Jane');
+  await userEvent.selectOptions(
+    screen.getByLabelText(/filing status/i),
+    'married'
+  );
   expect(setForm).toHaveBeenCalled();
 });

--- a/client/src/components/__tests__/StepperForm.test.jsx
+++ b/client/src/components/__tests__/StepperForm.test.jsx
@@ -10,8 +10,8 @@ test('navigates between steps', async () => {
   // First step shows intro heading
   expect(screen.getByText(/welcome to the w-4 calculator/i)).toBeInTheDocument();
   await userEvent.click(screen.getByText(/next/i));
-  // Next step should show personal information heading
+  // Next step should show filing status heading
   expect(
-    screen.getByRole('heading', { name: /personal information/i })
+    screen.getByRole('heading', { name: /filing status/i })
   ).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- rename "Personal Info" step to "Filing Status"
- trim the step so it only shows the filing status select
- drop unused personal data fields from StepperForm state and review defaults
- update related tests

## Testing
- `npm install`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6841013a067c832993c614f87739e6cd