### PR TITLE
Update review step layout with PDF preview

### DIFF
--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -1,8 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import StepReview from '../StepReview';
+import { fillW4Template } from '../utils/fillW4Template';
 
 jest.mock('../PaycheckPreview', () => () => <div>Preview</div>);
+jest.mock('../utils/fillW4Template', () => ({
+  fillW4Template: jest.fn(() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+}));
+
+beforeAll(() => {
+  const create = jest.fn(() => 'blob:preview');
+  const revoke = jest.fn();
+  global.URL.createObjectURL = create;
+  global.URL.revokeObjectURL = revoke;
+  if (window.URL) {
+    window.URL.createObjectURL = create;
+    window.URL.revokeObjectURL = revoke;
+  }
+});
 
 test('calls onDownload when button clicked', async () => {
   const onDownload = jest.fn();
@@ -11,41 +26,7 @@ test('calls onDownload when button clicked', async () => {
   expect(onDownload).toHaveBeenCalled();
 });
 
-test('does not display step2b data', () => {
-  render(
-    <StepReview
-      form={{ grossPay: 1000, step2b: { line1: 1 } }}
-      onDownload={() => {}}
-    />,
-  );
-  expect(screen.queryByText(/step2b/i)).not.toBeInTheDocument();
-});
-
-test('formats currency fields with dollar sign', () => {
-  render(
-    <StepReview
-      form={{ grossPay: 1000, extraWithholding: 50, secondJobIncome: 20, spouseIncome: 30 }}
-      onDownload={() => {}}
-    />,
-  );
-  expect(screen.getByText('$1,000')).toBeInTheDocument();
-  expect(screen.getByText('$50')).toBeInTheDocument();
-  expect(screen.getByText('$20')).toBeInTheDocument();
-  expect(screen.getByText('$30')).toBeInTheDocument();
-});
-
-test('formats pretax deductions with dollar sign and commas', () => {
-  render(
-    <StepReview form={{ pretaxDeductions: 12345 }} onDownload={() => {}} />,
-  );
-  expect(screen.getByText('$12,345')).toBeInTheDocument();
-});
-
-test('shows default values when form is empty', () => {
-  render(<StepReview form={{}} onDownload={() => {}} />);
-  expect(screen.getByText('Filing Status')).toBeInTheDocument();
-  expect(screen.getByText('single')).toBeInTheDocument();
-  expect(screen.getByText('Pay Frequency')).toBeInTheDocument();
-  expect(screen.getByText('biweekly')).toBeInTheDocument();
-  expect(screen.getAllByText('$0').length).toBeGreaterThan(0);
+test('generates pdf preview', async () => {
+  render(<StepReview form={{ grossPay: 1000 }} onDownload={() => {}} />);
+  await waitFor(() => expect(fillW4Template).toHaveBeenCalled());
 });


### PR DESCRIPTION
## Summary
- simplify `StepReview` component to remove entry list
- show Paycheck Preview first and display a PDF preview iframe
- update tests to check PDF generation and downloading

## Testing
- `npm --prefix client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841023141ac8329abd0e9bbe0792e01