### PR TITLE
Move download button to bottom right

### DIFF
--- a/client/src/components/StepReview.jsx
+++ b/client/src/components/StepReview.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PaycheckPreview from './PaycheckPreview';
 import { fillW4Template } from './utils/fillW4Template';
 
-export default function StepReview({ form, onDownload }) {
+export default function StepReview({ form }) {
   const [pdfUrl, setPdfUrl] = useState(null);
 
   useEffect(() => {
@@ -49,15 +49,6 @@ export default function StepReview({ form, onDownload }) {
         </div>
       )}
 
-      <div className="pt-4">
-        <button
-          type="button"
-          onClick={onDownload}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded"
-        >
-          Download Completed W-4 Form (PDF)
-        </button>
-      </div>
     </div>
   );
 }

--- a/client/src/components/StepperForm.jsx
+++ b/client/src/components/StepperForm.jsx
@@ -71,7 +71,7 @@ const steps = [
   return (
     <div className="max-w-6xl w-full mx-auto bg-white shadow-xl rounded-xl px-8 sm:px-12 py-12 space-y-6">
       <StepIndicator steps={steps} current={currentStep} />
-      <StepComponent form={form} setForm={setForm} onDownload={handleDownload} />
+      <StepComponent form={form} setForm={setForm} />
 
       <div className="flex justify-between items-center mt-6 px-4">
         <button
@@ -90,7 +90,15 @@ const steps = [
           >
             Next
           </button>
-        ) : null}
+        ) : (
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+          >
+            Download Completed W-4 Form (PDF)
+          </button>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/__tests__/StepReview.test.jsx
+++ b/client/src/components/__tests__/StepReview.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import StepReview from '../StepReview';
 import { fillW4Template } from '../utils/fillW4Template';
 
@@ -19,14 +18,8 @@ beforeAll(() => {
   }
 });
 
-test('calls onDownload when button clicked', async () => {
-  const onDownload = jest.fn();
-  render(<StepReview form={{ grossPay: 1000 }} onDownload={onDownload} />);
-  await userEvent.click(screen.getByRole('button', { name: /download/i }));
-  expect(onDownload).toHaveBeenCalled();
-});
 
 test('generates pdf preview', async () => {
-  render(<StepReview form={{ grossPay: 1000 }} onDownload={() => {}} />);
+  render(<StepReview form={{ grossPay: 1000 }} />);
   await waitFor(() => expect(fillW4Template).toHaveBeenCalled());
 });

--- a/client/src/components/__tests__/StepperForm.test.jsx
+++ b/client/src/components/__tests__/StepperForm.test.jsx
@@ -15,3 +15,15 @@ test('navigates between steps', async () => {
     screen.getByRole('heading', { name: /filing status/i })
   ).toBeInTheDocument();
 });
+
+test('shows download button on final step', async () => {
+  const { fillW4Template } = require('../utils/fillW4Template');
+  render(<StepperForm />);
+  // navigate to final step
+  while (screen.queryByRole('button', { name: /next/i })) {
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+  }
+  const download = screen.getByRole('button', { name: /download completed w-4 form/i });
+  await userEvent.click(download);
+  expect(fillW4Template).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- update StepReview to only render preview
- conditionally render Download button at bottom of StepperForm
- adjust StepReview and StepperForm tests for new placement

## Testing
- `npm test --silent --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841061c69ec8329a88e19b9adee74ab