### PR TITLE
Ensure even spacing in deductions view

### DIFF
--- a/client/src/components/CurrencyInput.jsx
+++ b/client/src/components/CurrencyInput.jsx
@@ -9,6 +9,7 @@ export default function CurrencyInput({
   max = Number.MAX_SAFE_INTEGER,
   helperText = '',
   icon: Icon,
+  className = 'mb-3',
 }) {
   const [error, setError] = useState('');
   const [rawInput, setRawInput] = useState('');
@@ -56,7 +57,7 @@ export default function CurrencyInput({
   };
 
   return (
-    <div className="mb-3">
+    <div className={className}>
       <label className="form-label d-flex align-items-center gap-1">
         {Icon && <Icon className="text-secondary" />}
         {label}

--- a/client/src/components/StepDeductionsWorksheet.jsx
+++ b/client/src/components/StepDeductionsWorksheet.jsx
@@ -22,31 +22,33 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
   }, [line1, line2, line3, line4, line5]);
 
   return (
-    <div className="mb-3">
-      <h2 className="h5 fw-semibold text-dark">Deductions</h2>
-
-      <CurrencyInput
-        label={<label htmlFor="itemizedDeductions" className="form-label">Estimated Itemized Deductions</label>}
-        name="itemizedDeductions"
-        value={form.itemizedDeductions}
-        onChange={(field, val) => setForm({ ...form, [field]: val })}
-        min={0}
-        max={1000000}
-        helperText="Amount of itemized deductions beyond the standard deduction"
-      />
-      <CurrencyInput
-        label={<label htmlFor="adjustmentDeductions" className="form-label">Other Adjustments to Income</label>}
-        name="adjustmentDeductions"
-        value={form.adjustmentDeductions}
-        onChange={(field, val) => setForm({ ...form, [field]: val })}
-        min={0}
-        max={1000000}
-        helperText="Other adjustments that reduce income"
-      />
-
-        <div className="p-3 bg-light border rounded">
-          <p className="small text-primary">Total Deductions (Beyond Standard Deduction): ${line5.toLocaleString()}</p>
-        </div>
+    <div className="mb-3 d-flex flex-column h-100">
+      <h2 className="h5 fw-semibold text-dark mb-3">Deductions</h2>
+      <div className="d-flex flex-column gap-3 flex-grow-1">
+        <CurrencyInput
+          className="mb-0"
+          label={<label htmlFor="itemizedDeductions" className="form-label">Estimated Itemized Deductions</label>}
+          name="itemizedDeductions"
+          value={form.itemizedDeductions}
+          onChange={(field, val) => setForm({ ...form, [field]: val })}
+          min={0}
+          max={1000000}
+          helperText="Amount of itemized deductions beyond the standard deduction"
+        />
+        <CurrencyInput
+          className="mb-0"
+          label={<label htmlFor="adjustmentDeductions" className="form-label">Other Adjustments to Income</label>}
+          name="adjustmentDeductions"
+          value={form.adjustmentDeductions}
+          onChange={(field, val) => setForm({ ...form, [field]: val })}
+          min={0}
+          max={1000000}
+          helperText="Other adjustments that reduce income"
+        />
+      </div>
+      <div className="p-3 bg-light border rounded mt-auto">
+        <p className="small text-primary">Total Deductions (Beyond Standard Deduction): ${line5.toLocaleString()}</p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add optional `className` prop to `CurrencyInput`
- adjust layout in `StepDeductionsWorksheet` to use full height and consistent spacing

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684122fbbe5083298ba9624e7f444b27