### PR TITLE
Rearrange dependents and adjustments fields

### DIFF
--- a/client/src/components/StepAdjustments.jsx
+++ b/client/src/components/StepAdjustments.jsx
@@ -1,52 +1,13 @@
 import React from 'react';
 import CurrencyInput from './CurrencyInput';
-import { FaPiggyBank, FaWallet, FaDollarSign } from 'react-icons/fa';
+import { FaPiggyBank, FaWallet, FaDollarSign, FaSlidersH } from 'react-icons/fa';
 
 export default function StepAdjustments({ form, setForm }) {
-  const handleNumberChange = (e, key) => {
-    const value = e.target.value.replace(/[^0-9.]/g, '');
-    setForm({ ...form, [key]: value });
-  };
 
   return (
     <div className="mb-3">
       <h2 className="h5 fw-semibold text-dark">Adjustments</h2>
-      <div>
-        <label
-          htmlFor="under17"
-          className="form-label"
-          title="Number of dependents under age 17"
-        >
-          Dependents Under 17
-        </label>
-        <input
-          id="under17"
-          type="number"
-          min="0"
-          value={form.under17 || ''}
-          onChange={(e) => handleNumberChange(e, 'under17')}
-          className="form-control"
-          placeholder="0"
-        />
-      </div>
-      <div>
-        <label
-          htmlFor="otherDependents"
-          className="form-label"
-          title="Dependents age 17 or older"
-        >
-          Other Dependents
-        </label>
-        <input
-          id="otherDependents"
-          type="number"
-          min="0"
-          value={form.otherDependents || ''}
-          onChange={(e) => handleNumberChange(e, 'otherDependents')}
-          className="form-control"
-          placeholder="0"
-        />
-      </div>
+
 
 
       <div>
@@ -110,6 +71,22 @@ export default function StepAdjustments({ form, setForm }) {
           max={10000}
           helperText="Any extra amount you'd like withheld from each paycheck."
           icon={FaDollarSign}
+        />
+      </div>
+      <div>
+        <CurrencyInput
+          label={
+            <label htmlFor="adjustmentDeductions" className="form-label">
+              Other Adjustments to Income
+            </label>
+          }
+          name="adjustmentDeductions"
+          value={form.adjustmentDeductions}
+          onChange={(field, val) => setForm({ ...form, [field]: val })}
+          min={0}
+          max={1000000}
+          helperText="Other adjustments that reduce income"
+          icon={FaSlidersH}
         />
       </div>
     </div>

--- a/client/src/components/StepDeductionsWorksheet.jsx
+++ b/client/src/components/StepDeductionsWorksheet.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import CurrencyInput from './CurrencyInput';
-import { FaFileInvoiceDollar, FaSlidersH } from 'react-icons/fa';
+import { FaFileInvoiceDollar } from 'react-icons/fa';
 import { calculateStep4b } from './utils/calculateStep4b';
 
 export default function StepDeductionsWorksheet({ form, setForm }) {
@@ -37,17 +37,34 @@ export default function StepDeductionsWorksheet({ form, setForm }) {
           helperText="Amount of itemized deductions beyond the standard deduction"
           icon={FaFileInvoiceDollar}
         />
-        <CurrencyInput
-          className="mb-0"
-          label={<label htmlFor="adjustmentDeductions" className="form-label">Other Adjustments to Income</label>}
-          name="adjustmentDeductions"
-          value={form.adjustmentDeductions}
-          onChange={(field, val) => setForm({ ...form, [field]: val })}
-          min={0}
-          max={1000000}
-          helperText="Other adjustments that reduce income"
-          icon={FaSlidersH}
-        />
+        <div>
+          <label htmlFor="under17" className="form-label" title="Number of dependents under age 17">
+            Dependents Under 17
+          </label>
+          <input
+            id="under17"
+            type="number"
+            min="0"
+            value={form.under17 || ''}
+            onChange={(e) => setForm({ ...form, under17: e.target.value.replace(/[^0-9.]/g, '') })}
+            className="form-control"
+            placeholder="0"
+          />
+        </div>
+        <div>
+          <label htmlFor="otherDependents" className="form-label" title="Dependents age 17 or older">
+            Other Dependents
+          </label>
+          <input
+            id="otherDependents"
+            type="number"
+            min="0"
+            value={form.otherDependents || ''}
+            onChange={(e) => setForm({ ...form, otherDependents: e.target.value.replace(/[^0-9.]/g, '') })}
+            className="form-control"
+            placeholder="0"
+          />
+        </div>
       </div>
       <div className="p-3 bg-light border rounded mt-auto">
         <p className="small text-primary">Total Deductions (Beyond Standard Deduction): ${line5.toLocaleString()}</p>


### PR DESCRIPTION
## Summary
- move dependent inputs to deduction step
- show other adjustments input in adjustment step

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842342e5cdc83298c4c2cf99fb096cc