### PR TITLE
Implement step view analytics

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-jest.mock('@vercel/analytics', () => ({ inject: jest.fn() }));
+jest.mock('@vercel/analytics', () => ({ inject: jest.fn(), track: jest.fn() }));
 jest.mock('jspdf', () => jest.fn());
 
 test('renders app header', () => {

--- a/client/src/components/StepperForm.jsx
+++ b/client/src/components/StepperForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import StepIndicator from './StepIndicator';
 import StepMultipleJobs from './StepMultipleJobs';
 import StepIncomeDetails from './StepIncomeDetails';
@@ -7,6 +7,7 @@ import StepDeductionsWorksheet from './StepDeductionsWorksheet';
 import StepReview from './StepReview';
 import StepIntro from './StepIntro';
 import { fillW4Template } from './utils/fillW4Template';
+import { track } from '@vercel/analytics';
 
 
 import jsPDF from 'jspdf';
@@ -66,6 +67,10 @@ const steps = [
 ];
 
   const StepComponent = steps[currentStep].Component;
+
+  useEffect(() => {
+    track('step_view', { step: steps[currentStep].title });
+  }, [currentStep]);
   return (
     <div
       className="container bg-white shadow rounded p-4 my-4 d-flex flex-column stepper-form-container"

--- a/client/src/components/__tests__/StepperForm.test.jsx
+++ b/client/src/components/__tests__/StepperForm.test.jsx
@@ -4,6 +4,7 @@ import StepperForm from '../StepperForm';
 
 jest.mock('jspdf', () => jest.fn());
 jest.mock('../utils/fillW4Template', () => ({ fillW4Template: jest.fn() }));
+jest.mock('@vercel/analytics', () => ({ track: jest.fn() }));
 
 test('navigates between steps', async () => {
   render(<StepperForm />);
@@ -14,6 +15,16 @@ test('navigates between steps', async () => {
   expect(
     screen.getByRole('heading', { name: /pay & withholding/i })
   ).toBeInTheDocument();
+});
+
+test('logs step views when navigating', async () => {
+  const { track } = require('@vercel/analytics');
+  render(<StepperForm />);
+  await screen.findByText(/welcome to the w-4 calculator/i);
+  expect(track).toHaveBeenCalledWith('step_view', { step: 'Welcome' });
+  await userEvent.click(screen.getByText(/next/i));
+  await screen.findByRole('heading', { name: /pay & withholding/i });
+  expect(track).toHaveBeenCalledWith('step_view', { step: 'Pay & Withholding' });
 });
 
 test('shows download button on final step', async () => {


### PR DESCRIPTION
## Summary
- add `track` analytics calls when a step is shown
- mock analytics in tests and add a new test verifying step logging

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842fb0510508329bb8de9c242081535